### PR TITLE
Feature/more stuff

### DIFF
--- a/RackEmUp.csproj
+++ b/RackEmUp.csproj
@@ -30,8 +30,12 @@
 			<HintPath>$(VINTAGE_STORY)/Lib/protobuf-net.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
-		<Reference Include="CarryOnLib">
+		<Reference Include="CarryOnLib" Condition="'$(Configuration)' == 'Debug'">
 			<HintPath>..\CarryOnLib\bin\Debug\net8.0\CarryOnLib.dll</HintPath>
+			<Private>false</Private>
+		</Reference>	
+		<Reference Include="CarryOnLib" Condition="'$(Configuration)' == 'Release'">
+			<HintPath>..\CarryOnLib\bin\Release\net8.0\CarryOnLib.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
 

--- a/src/BlockBehaviorMoldRackTransfer.cs
+++ b/src/BlockBehaviorMoldRackTransfer.cs
@@ -1,12 +1,13 @@
 using System.Linq;
-using CarryOn.API.Common;
+using CarryOn.API.Common.Interfaces;
+using CarryOn.API.Common.Models;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 using Vintagestory.GameContent;
-using static CarryOn.API.Common.CarryCode;
+using static CarryOn.API.Common.Models.CarryCode;
 using static CarryOn.Utility.JsonHelper;
 
 namespace CarryOn.RackEmUp

--- a/src/Core.cs
+++ b/src/Core.cs
@@ -1,4 +1,4 @@
-using CarryOn.API.Common;
+using CarryOn.API.Common.Interfaces;
 using Vintagestory.API.Common;
 
 [assembly: ModInfo("CarryOn RackEmUp",


### PR DESCRIPTION
This pull request updates project references and refines the usage of namespaces and types from the `CarryOn` library to improve code organization and build configuration handling. The most important changes are grouped below:

**Project Reference Improvements:**

* Updated the `CarryOnLib` reference in `RackEmUp.csproj` to conditionally reference the Debug or Release build of the DLL based on the current build configuration, ensuring the correct library version is used for each build type.

**Namespace and Type Usage Refinement:**

* Changed imports in `src/BlockBehaviorMoldRackTransfer.cs` and `src/Core.cs` to use more specific namespaces from `CarryOn.API.Common`, switching from general to `Interfaces` and `Models` namespaces for improved clarity and separation of concerns. [[1]](diffhunk://#diff-18a4a454ba08769c150c0a3ef2a3b2cfaf72bc007012745c0dbf887a7d3ee443L2-R10) [[2]](diffhunk://#diff-5da8214f573485695684ab2560cba0e14a928b48bce04387b733f22055b61488L1-R1)
* Updated static import of `CarryCode` to reference it from `CarryOn.API.Common.Models` instead of the previous location, aligning with the new project structure.